### PR TITLE
Add includes for CoreFoundation.h and CoreServices.h

### DIFF
--- a/handler.h
+++ b/handler.h
@@ -1,3 +1,6 @@
+#include <CoreFoundation/CoreFoundation.h>
+#include <CoreServices/CoreServices.h>
+
 struct roles {
   const char *r_role;
   LSRolesMask r_mask;

--- a/plist.h
+++ b/plist.h
@@ -1,3 +1,5 @@
+#include <CoreFoundation/CoreFoundation.h>
+
 int read_plist(char *, CFDictionaryRef *);
 
 /* plist keys */

--- a/util.h
+++ b/util.h
@@ -1,3 +1,5 @@
+#include <CoreFoundation/CoreFoundation.h>
+
 struct ll {
   char *l_path;
   struct ll *l_next;


### PR DESCRIPTION
Was getting errors like

error: unknown type name 'LSRolesMask'
error: unknown type name 'CFStringRef'

when building with bazel + Apple crosstool 
